### PR TITLE
Consolidate "FileSystem as Wallhaven DB" logic in a single module

### DIFF
--- a/app/Wallhaven/Env.hs
+++ b/app/Wallhaven/Env.hs
@@ -1,7 +1,6 @@
 module Wallhaven.Env (Env (..), Config (..)) where
 
 import Control.Monad.Reader (ReaderT, asks)
-import Database.FileSystem.Action (deleteFileIfExists)
 import qualified Network.HTTP.Conduit as HTTP
 import qualified Network.HTTP.Simple as HTTP
 import Network.HTTP.Types (unauthorized401)
@@ -13,6 +12,7 @@ import qualified Types
 import UnliftIO (MonadUnliftIO, catch, throwIO)
 import UnliftIO.Directory (createDirectoryIfMissing, listDirectory)
 import UnliftIO.IO.File (writeBinaryFile)
+import Util.FileSystem (deleteFileIfExists)
 import qualified Wallhaven.API.Action as WallhavenAPI
 import Wallhaven.API.Exception (CollectionURLsFetchException (..))
 import Wallhaven.Exception (WallhavenSyncException (..))

--- a/app/Wallhaven/Env.hs
+++ b/app/Wallhaven/Env.hs
@@ -1,7 +1,7 @@
 module Wallhaven.Env (Env (..), Config (..)) where
 
 import Control.Monad.Reader (ReaderT, asks)
-import qualified Database.FileSystem.Action as DBFileSystem
+import Database.FileSystem.Action (deleteFileIfExists)
 import qualified Network.HTTP.Conduit as HTTP
 import qualified Network.HTTP.Simple as HTTP
 import Network.HTTP.Types (unauthorized401)
@@ -11,6 +11,8 @@ import System.IO.Error (isPermissionError)
 import Types (FullWallpaperURL, Label, Username, WallpaperName)
 import qualified Types
 import UnliftIO (MonadUnliftIO, catch, throwIO)
+import UnliftIO.Directory (createDirectoryIfMissing, listDirectory)
+import UnliftIO.IO.File (writeBinaryFile)
 import qualified Wallhaven.API.Action as WallhavenAPI
 import Wallhaven.API.Exception (CollectionURLsFetchException (..))
 import Wallhaven.Exception (WallhavenSyncException (..))
@@ -135,7 +137,7 @@ instance (MonadUnliftIO m) => MonadDeleteWallpaper (ReaderT Env m) where
   deleteWallpaper name = do
     dir <- asks (configWallpaperDir . envConfig)
     catch
-      (DBFileSystem.deleteWallpaper dir name)
+      (deleteFileIfExists $ dir </> name)
       (throwIO . deleteWallpaperExceptionHandler dir name)
 
 deleteWallpaperExceptionHandler ::
@@ -156,7 +158,7 @@ instance (MonadUnliftIO m) => MonadSaveWallpaper (ReaderT Env m) where
   saveWallpaper name wallpaper = do
     dir <- asks (configWallpaperDir . envConfig)
     catch
-      (DBFileSystem.saveWallpaper dir name wallpaper)
+      (writeBinaryFile (dir </> name) wallpaper)
       (throwIO . saveWallpaperExceptionHandler dir name)
 
 saveWallpaperExceptionHandler ::
@@ -177,7 +179,7 @@ instance (MonadUnliftIO m) => MonadInitDB (ReaderT Env m) where
   initDB = do
     dir <- asks (configWallpaperDir . envConfig)
     catch
-      (DBFileSystem.createWallpaperDir dir)
+      (createDirectoryIfMissing True dir)
       (throwIO . initDBExceptionHandler dir)
 
 initDBExceptionHandler :: FilePath -> IOError -> WallhavenSyncException
@@ -201,7 +203,7 @@ instance
   getDownloadedWallpapers = do
     dir <- asks (configWallpaperDir . envConfig)
     catch
-      (DBFileSystem.getWallpaperNames dir)
+      (listDirectory dir)
       (throwIO . getDownloadedWallpapersExceptionHandler dir)
 
 getDownloadedWallpapersExceptionHandler ::

--- a/src/Database/FileSystem/Action.hs
+++ b/src/Database/FileSystem/Action.hs
@@ -1,38 +1,10 @@
-module Database.FileSystem.Action
-  ( deleteWallpaper,
-    saveWallpaper,
-    getWallpaperNames,
-    createWallpaperDir,
-  )
-where
+module Database.FileSystem.Action (deleteFileIfExists) where
 
 import Control.Monad (when)
-import Control.Monad.Reader (liftIO)
-import System.FilePath ((</>))
-import Types (Wallpaper, WallpaperName)
 import UnliftIO (MonadIO)
-import UnliftIO.Directory
-  ( createDirectoryIfMissing,
-    doesFileExist,
-    listDirectory,
-    removeFile,
-  )
-import UnliftIO.IO.File (writeBinaryFile)
+import UnliftIO.Directory (doesFileExist, removeFile)
 
-type WallpaperDir = FilePath
-
-createWallpaperDir :: MonadIO m => WallpaperDir -> m ()
-createWallpaperDir = liftIO . createDirectoryIfMissing True
-
-deleteWallpaper :: MonadIO m => WallpaperDir -> WallpaperName -> m ()
-deleteWallpaper dir name = do
-  let path = dir </> name
+deleteFileIfExists :: MonadIO m => FilePath -> m ()
+deleteFileIfExists path = do
   exists <- doesFileExist path
   when exists $ removeFile path
-
-getWallpaperNames :: MonadIO m => WallpaperDir -> m [WallpaperName]
-getWallpaperNames = listDirectory
-
-saveWallpaper ::
-  MonadIO m => WallpaperDir -> WallpaperName -> Wallpaper -> m ()
-saveWallpaper dir name = writeBinaryFile (dir </> name)

--- a/src/Util/FileSystem.hs
+++ b/src/Util/FileSystem.hs
@@ -1,4 +1,4 @@
-module Database.FileSystem.Action (deleteFileIfExists) where
+module Util.FileSystem (deleteFileIfExists) where
 
 import Control.Monad (when)
 import UnliftIO (MonadIO)

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -23,18 +23,15 @@ library wallhaven-sync-internal
         Util.List
         Util.Batch
         Util.HTTP
-
+        Util.FileSystem
         Wallhaven.Logic
         Wallhaven.Exception
         Wallhaven.Monad
         Wallhaven.Action
-
         Wallhaven.API.Action
         Wallhaven.API.Exception
         Wallhaven.API.Types
         Wallhaven.API.Logic
-
-        Database.FileSystem.Action
 
     hs-source-dirs:     src
     default-language:   Haskell2010
@@ -96,7 +93,6 @@ test-suite spec
         RetrySpec
         Util.Gen
         Util.BatchSpec
-
         Wallhaven.API.TypesSpec
         Wallhaven.API.LogicSpec
 


### PR DESCRIPTION
Right now the knowledge of using FileSystem as wallhaven database is in both `Database.FileSystem.Action` and `Wallhaven.Env` modules. This feels like a code-smell to me. Removing `Database.FileSystem.Action` module and consolidating all "FileSystem as Wallhaven DB" logic into `Wallhaven,.Env` module. Later we should refactor all the logic out of `Wallhaven.Env` into a new module. 

Closes #2 