### PR TITLE
Sync wallpapers with batching, print time taken to sync

### DIFF
--- a/app/Wallhaven/Env.hs
+++ b/app/Wallhaven/Env.hs
@@ -47,6 +47,9 @@ instance HasDeleteUnliked Env where
 instance HasLog Env where
   getLog = envLog
 
+instance HasSyncParallelization Env where
+  getSyncParallelization = configNumParallelDownloads . envConfig
+
 instance (MonadUnliftIO m) => MonadGetCollectionURLs (ReaderT Env m) where
   getCollectionURLs username label = do
     apiKey <- asks (configWallhavenAPIKey . envConfig)

--- a/src/Util/Batch.hs
+++ b/src/Util/Batch.hs
@@ -1,5 +1,6 @@
-module Util.Batch (batchedM) where
+module Util.Batch (batchedM, batchedM_) where
 
+import Control.Monad (void)
 import UnliftIO (MonadUnliftIO, mapConcurrently)
 import qualified Util.List as List
 
@@ -12,3 +13,7 @@ batchedM size f =
   fmap concat
     . mapM (mapConcurrently f)
     . List.batches size
+
+batchedM_ ::
+  (MonadUnliftIO m) => Int -> (a -> m b) -> [a] -> m ()
+batchedM_ size f = void . batchedM size f

--- a/src/Util/Time.hs
+++ b/src/Util/Time.hs
@@ -1,4 +1,17 @@
-module Util.Time (seconds) where
+module Util.Time (seconds, timed, timed_) where
+
+import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
+import UnliftIO (MonadIO (liftIO), MonadUnliftIO)
 
 seconds :: Int -> Int
 seconds n = n * 10 ^ (6 :: Int)
+
+timed :: (MonadUnliftIO m) => m a -> m (a, NominalDiffTime)
+timed action = do
+  start <- liftIO getCurrentTime
+  result <- action
+  end <- liftIO getCurrentTime
+  return (result, diffUTCTime end start)
+
+timed_ :: (MonadUnliftIO m) => m a -> m NominalDiffTime
+timed_ action = do (_, time) <- timed action; return time

--- a/src/Wallhaven/Action.hs
+++ b/src/Wallhaven/Action.hs
@@ -3,15 +3,19 @@ module Wallhaven.Action (deleteUnlikedWallpapers, syncAllWallpapers) where
 import Control.Monad (forever, unless, when)
 import Control.Monad.Reader (MonadReader, asks)
 import qualified Data.List as List
+import Data.Time (diffUTCTime, getCurrentTime, nominalDiffTimeToSeconds)
+import Text.Printf (printf)
 import Types (FullWallpaperURL, Label, Username, WallpaperName)
 import UnliftIO
 import UnliftIO.Concurrent (threadDelay)
+import Util.Batch (batchedM_)
 import Wallhaven.Exception (WallhavenSyncException (..))
 import Wallhaven.Logic (wallpaperName)
 import Wallhaven.Monad
   ( HasDebug,
     HasDeleteUnliked,
     HasLog,
+    HasSyncParallelization,
     MonadInitDB (initDB),
     MonadWallhaven,
     MonadWallpaperDB,
@@ -22,6 +26,7 @@ import Wallhaven.Monad
     getDeleteUnliked,
     getDownloadedWallpapers,
     getLog,
+    getSyncParallelization,
     saveWallpaper,
   )
 import Prelude hiding (log, writeFile)
@@ -30,6 +35,7 @@ type AppM env m =
   ( MonadReader env m,
     HasDeleteUnliked env,
     HasLog env,
+    HasSyncParallelization env,
     MonadWallhaven m,
     MonadWallpaperDB m,
     HasDebug env,
@@ -53,6 +59,7 @@ handleException e = do
 
 syncAllWallpapers' :: AppM env m => Username -> Label -> m ()
 syncAllWallpapers' username label = do
+  startTime <- liftIO getCurrentTime
   initDB
   urls <- getCollectionURLs username label
   let names = fmap wallpaperName urls
@@ -63,19 +70,33 @@ syncAllWallpapers' username label = do
     logLn "Following wallpapers were found to be unliked and so were deleted:"
     mapM_ logLn unliked
   syncWallpapers downloaded $ names `zip` urls
-  logLn "\nAll wallpapers synced successfully."
+  timeTaken <-
+    diffUTCTime
+      <$> liftIO getCurrentTime
+      <*> pure startTime
+  let timeTakenSecs = realToFrac (nominalDiffTimeToSeconds timeTaken) :: Double
+  logLn $
+    "\nAll wallpapers synced successfully in "
+      <> printf "%.2f" timeTakenSecs
+      <> " seconds."
 
 -- | Syncs the provided wallpapers with the database.
 syncWallpapers ::
   AppM env m => [WallpaperName] -> [(WallpaperName, FullWallpaperURL)] -> m ()
 syncWallpapers downloaded wallpapers = do
   progressVar <- newMVar 0
+  parallelization <- asks getSyncParallelization
   withAsync
     ( forever $ do
         printProgressBar progressVar (length wallpapers)
         threadDelay 100000
     )
-    (const $ mapM_ (uncurry $ syncWallpaper progressVar downloaded) wallpapers)
+    ( const
+        . batchedM_
+          parallelization
+          (uncurry (syncWallpaper progressVar downloaded))
+        $ wallpapers
+    )
   printProgressBar progressVar (length wallpapers)
 
 -- | Syncs a single wallpaper. Skips downloading if the wallpaper is already

--- a/src/Wallhaven/Monad.hs
+++ b/src/Wallhaven/Monad.hs
@@ -10,6 +10,7 @@ module Wallhaven.Monad
     MonadWallpaperDB,
     MonadWallhaven,
     MonadDownloadWallpaper (..),
+    HasSyncParallelization (..),
   )
 where
 
@@ -24,6 +25,9 @@ class HasDeleteUnliked a where
 
 class HasLog a where
   getLog :: a -> (String -> IO ())
+
+class HasSyncParallelization a where
+  getSyncParallelization :: a -> Int
 
 -- | Monad for interacting with a database for wallpapers.
 type MonadWallpaperDB m =

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -51,6 +51,7 @@ library wallhaven-sync-internal
         split ^>=0.2.3.5,
         http-types ^>=0.12.3,
         aeson ^>=2.1.1.0,
+        time ^>=1.12.2,
         unliftio ^>=0.2.23.0
 
 executable wallhaven-sync


### PR DESCRIPTION
* Sync wallpapers in batches to increase speed.
* Print time taken for syncing.

Closes #7 
Closes #6 