### PR TITLE
Add implementation modules

### DIFF
--- a/app/Wallhaven/Env.hs
+++ b/app/Wallhaven/Env.hs
@@ -1,41 +1,31 @@
 module Wallhaven.Env (Env (..), Config (..)) where
 
 import Control.Monad.Reader (ReaderT, asks)
-import qualified Network.HTTP.Conduit as HTTP
-import qualified Network.HTTP.Simple as HTTP
-import Network.HTTP.Types (unauthorized401)
-import Network.HTTP.Types.Status (notFound404)
-import System.FilePath ((</>))
-import System.IO.Error (isPermissionError)
-import Types (FullWallpaperURL, Label, Username, WallpaperName)
 import qualified Types
-import UnliftIO (MonadUnliftIO, catch, throwIO)
-import UnliftIO.Directory (createDirectoryIfMissing, listDirectory)
-import UnliftIO.IO.File (writeBinaryFile)
-import Util.FileSystem (deleteFileIfExists)
-import qualified Wallhaven.API.Action as WallhavenAPI
-import Wallhaven.API.Exception (CollectionURLsFetchException (..))
-import Wallhaven.Exception (WallhavenSyncException (..))
+import UnliftIO (MonadUnliftIO)
+import qualified Wallhaven.Implementation.API as API
+import qualified Wallhaven.Implementation.FileSystemDB as FileSystemDB
 import Wallhaven.Monad
 import Prelude hiding (log)
 
+-- Environment record
 data Env = Env
   { envConfig :: !Config,
     envLog :: !(String -> IO ())
   }
 
--- Configuration structure.
+-- Configuration record
 data Config = Config
   { -- | The directory where the wallpapers will be saved.
-    configWallpaperDir :: FilePath,
+    configWallpaperDir :: !FilePath,
     -- | The number of wallpapers to download in parallel.
-    configNumParallelDownloads :: Types.NumParallelDownloads,
+    configNumParallelDownloads :: !Types.NumParallelDownloads,
     -- | Whether to delete unliked wallpapers.
-    configDeleteUnliked :: Bool,
+    configDeleteUnliked :: !Bool,
     -- | Wallhaven API Key
-    configWallhavenAPIKey :: String,
+    configWallhavenAPIKey :: !String,
     -- | Debug mode
-    configDebug :: Bool
+    configDebug :: !Bool
   }
 
 instance HasDebug Env where
@@ -53,173 +43,24 @@ instance HasSyncParallelization Env where
 instance (MonadUnliftIO m) => MonadGetCollectionURLs (ReaderT Env m) where
   getCollectionURLs username label = do
     apiKey <- asks (configWallhavenAPIKey . envConfig)
-    catch
-      (WallhavenAPI.getAllCollectionURLs apiKey username label)
-      (throwIO . collectionFetchExceptionHandler username label)
-
-collectionFetchExceptionHandler ::
-  Username -> Label -> CollectionURLsFetchException -> WallhavenSyncException
-collectionFetchExceptionHandler
-  username
-  label
-  ( UserCollectionsHTTPException
-      (HTTP.HttpExceptionRequest _ (HTTP.StatusCodeException res _))
-    )
-    | HTTP.getResponseStatus res == unauthorized401 =
-        let oneLine =
-              "not authorized to access user collections,"
-                <> " is your API key valid?"
-            verbose = show res
-         in CollectionFetchException username label oneLine verbose
-    | HTTP.getResponseStatus res == notFound404 =
-        let oneLine =
-              "no collections found for user "
-                <> username
-                <> ","
-                <> " is the username valid?"
-            verbose = show res
-         in CollectionFetchException username label oneLine verbose
-collectionFetchExceptionHandler
-  username
-  label
-  (UserCollectionsHTTPException e) =
-    let oneLine = "HTTP request to list user collections failed"
-     in CollectionFetchException username label oneLine (show e)
-collectionFetchExceptionHandler
-  username
-  label
-  (UserCollectionsParseException jsonErr) =
-    let oneLine = "failed to parse user collections API response"
-     in CollectionFetchException username label oneLine jsonErr
-collectionFetchExceptionHandler
-  username
-  label
-  (CollectionNotFoundException _) =
-    let oneLine = "collection " <> label <> " was not found"
-     in CollectionFetchException username label oneLine oneLine
-collectionFetchExceptionHandler
-  username
-  label
-  (CollectionFetchHTTPException cid page e) =
-    let oneLine =
-          "HTTP request to fetch page "
-            <> show page
-            <> " of collection with ID "
-            <> show cid
-            <> " failed"
-     in CollectionFetchException username label oneLine (show e)
-collectionFetchExceptionHandler
-  username
-  label
-  (MetaParseException cid jsonErr) =
-    let oneLine =
-          "failed to parse collection metadata from API response"
-            <> " for collection with ID "
-            <> show cid
-     in CollectionFetchException username label oneLine jsonErr
-collectionFetchExceptionHandler
-  username
-  label
-  (WallpaperURLsParseException jsonErr) =
-    let oneLine = "failed to parse wallpaper URLs from API response"
-     in CollectionFetchException username label oneLine jsonErr
+    API.getCollectionURLs apiKey username label
 
 instance MonadUnliftIO m => MonadDownloadWallpaper (ReaderT Env m) where
-  downloadWallpaper url =
-    catch
-      (WallhavenAPI.getFullWallpaper url)
-      (throwIO . wallpaperDownloadExceptionHandler url)
-
-wallpaperDownloadExceptionHandler ::
-  FullWallpaperURL -> HTTP.HttpException -> WallhavenSyncException
-wallpaperDownloadExceptionHandler url e =
-  let oneLine = "HTTP request to download wallpaper failed"
-   in WallpaperDownloadException url oneLine (show e)
+  downloadWallpaper = API.downloadWallpaper
 
 instance (MonadUnliftIO m) => MonadDeleteWallpaper (ReaderT Env m) where
-  deleteWallpaper name = do
-    dir <- asks (configWallpaperDir . envConfig)
-    catch
-      (deleteFileIfExists $ dir </> name)
-      (throwIO . deleteWallpaperExceptionHandler dir name)
-
-deleteWallpaperExceptionHandler ::
-  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
-deleteWallpaperExceptionHandler dir name e
-  | isPermissionError e =
-      let oneLine =
-            "no permission to delete wallpaper file " <> (dir </> name)
-          verbose = show e
-       in DeleteWallpaperException name oneLine verbose
-  | otherwise =
-      DeleteWallpaperException
-        name
-        ("failed to delete wallpaper file " <> (dir </> name))
-        (show e)
+  deleteWallpaper name =
+    asks (configWallpaperDir . envConfig)
+      >>= flip FileSystemDB.deleteWallpaper name
 
 instance (MonadUnliftIO m) => MonadSaveWallpaper (ReaderT Env m) where
   saveWallpaper name wallpaper = do
     dir <- asks (configWallpaperDir . envConfig)
-    catch
-      (writeBinaryFile (dir </> name) wallpaper)
-      (throwIO . saveWallpaperExceptionHandler dir name)
-
-saveWallpaperExceptionHandler ::
-  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
-saveWallpaperExceptionHandler dir name e
-  | isPermissionError e =
-      let oneLine =
-            "no permission to save wallpaper to file " <> (dir </> name)
-          verbose = show e
-       in SaveWallpaperException name oneLine verbose
-  | otherwise =
-      SaveWallpaperException
-        name
-        ("failed to save wallpaper to file " <> (dir </> name))
-        (show e)
+    FileSystemDB.saveWallpaper dir name wallpaper
 
 instance (MonadUnliftIO m) => MonadInitDB (ReaderT Env m) where
-  initDB = do
-    dir <- asks (configWallpaperDir . envConfig)
-    catch
-      (createDirectoryIfMissing True dir)
-      (throwIO . initDBExceptionHandler dir)
+  initDB = asks (configWallpaperDir . envConfig) >>= FileSystemDB.initDB
 
-initDBExceptionHandler :: FilePath -> IOError -> WallhavenSyncException
-initDBExceptionHandler dir e
-  | isPermissionError e =
-      let oneLine =
-            "no permission to create wallpaper directory '"
-              <> dir
-              <> "'"
-          verbose = show e
-       in InitDBException oneLine verbose
-  | otherwise =
-      InitDBException
-        ("failed to create wallpaper directory '" <> dir <> "'")
-        (show e)
-
-instance
-  (MonadUnliftIO m) =>
-  MonadGetDownloadedWallpapers (ReaderT Env m)
-  where
-  getDownloadedWallpapers = do
-    dir <- asks (configWallpaperDir . envConfig)
-    catch
-      (listDirectory dir)
-      (throwIO . getDownloadedWallpapersExceptionHandler dir)
-
-getDownloadedWallpapersExceptionHandler ::
-  FilePath -> IOError -> WallhavenSyncException
-getDownloadedWallpapersExceptionHandler dir e
-  | isPermissionError e =
-      let oneLine =
-            "no permission to list contents of wallpaper directory '"
-              <> dir
-              <> "'"
-          verbose = show e
-       in InitDBException oneLine verbose
-  | otherwise =
-      InitDBException
-        ("failed to list contents of wallpaper directory '" <> dir <> "'")
-        (show e)
+instance (MonadUnliftIO m) => MonadGetDownloadedWallpapers (ReaderT Env m) where
+  getDownloadedWallpapers =
+    asks (configWallpaperDir . envConfig) >>= FileSystemDB.getDownloadedWallpapers

--- a/src/Util/HTTP.hs
+++ b/src/Util/HTTP.hs
@@ -15,9 +15,9 @@ import Network.HTTP.Simple
     httpBS,
   )
 import Network.HTTP.Types (tooManyRequests429)
-import Retry (MaxAttempts, RetryDelayMicros, retryM)
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (throwIO, try)
+import Util.Retry (MaxAttempts, RetryDelayMicros, retryM)
 
 httpBSWithRetry ::
   (MonadUnliftIO m) =>

--- a/src/Util/Retry.hs
+++ b/src/Util/Retry.hs
@@ -1,4 +1,4 @@
-module Retry (retryM, MaxAttempts, RetryDelayMicros) where
+module Util.Retry (retryM, MaxAttempts, RetryDelayMicros) where
 
 import UnliftIO (MonadIO)
 import UnliftIO.Concurrent (threadDelay)

--- a/src/Wallhaven/API/Action.hs
+++ b/src/Wallhaven/API/Action.hs
@@ -3,12 +3,12 @@ module Wallhaven.API.Action (getAllCollectionURLs, getFullWallpaper) where
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Network.HTTP.Simple (Request, parseRequest_)
-import qualified Retry
 import Types
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception
 import Util.Batch (batchedM)
 import Util.HTTP (httpBSWithRetry, isTooManyRequestsException)
+import qualified Util.Retry as Retry
 import Util.Time (seconds)
 import qualified Wallhaven.API.Exception as Exception
 import Wallhaven.API.Logic

--- a/src/Wallhaven/Implementation/API.hs
+++ b/src/Wallhaven/Implementation/API.hs
@@ -1,0 +1,102 @@
+-- Provides functions that implement Wallhaven interaction interface to be used when
+-- constructing environments.
+module Wallhaven.Implementation.API (getCollectionURLs, downloadWallpaper) where
+
+import Data.ByteString (ByteString)
+import qualified Network.HTTP.Client.Conduit as HTTP
+import qualified Network.HTTP.Simple as HTTP
+import Network.HTTP.Types.Status (notFound404, unauthorized401)
+import Types (FullWallpaperURL, Label, Username)
+import UnliftIO (MonadUnliftIO, catch, throwIO)
+import qualified Wallhaven.API.Action as WallhavenAPI
+import Wallhaven.API.Exception (CollectionURLsFetchException (..))
+import Wallhaven.Exception
+  ( WallhavenSyncException (CollectionFetchException, WallpaperDownloadException),
+  )
+
+getCollectionURLs ::
+  (MonadUnliftIO m) => String -> Username -> Label -> m [FullWallpaperURL]
+getCollectionURLs apiKey username label =
+  catch
+    (WallhavenAPI.getAllCollectionURLs apiKey username label)
+    (throwIO . collectionFetchExceptionHandler username label)
+
+collectionFetchExceptionHandler ::
+  Username -> Label -> CollectionURLsFetchException -> WallhavenSyncException
+collectionFetchExceptionHandler
+  username
+  label
+  ( UserCollectionsHTTPException
+      (HTTP.HttpExceptionRequest _ (HTTP.StatusCodeException res _))
+    )
+    | HTTP.getResponseStatus res == unauthorized401 =
+        let oneLine =
+              "not authorized to access user collections,"
+                <> " is your API key valid?"
+            verbose = show res
+         in CollectionFetchException username label oneLine verbose
+    | HTTP.getResponseStatus res == notFound404 =
+        let oneLine =
+              "no collections found for user "
+                <> username
+                <> ","
+                <> " is the username valid?"
+            verbose = show res
+         in CollectionFetchException username label oneLine verbose
+collectionFetchExceptionHandler
+  username
+  label
+  (UserCollectionsHTTPException e) =
+    let oneLine = "HTTP request to list user collections failed"
+     in CollectionFetchException username label oneLine (show e)
+collectionFetchExceptionHandler
+  username
+  label
+  (UserCollectionsParseException jsonErr) =
+    let oneLine = "failed to parse user collections API response"
+     in CollectionFetchException username label oneLine jsonErr
+collectionFetchExceptionHandler
+  username
+  label
+  (CollectionNotFoundException _) =
+    let oneLine = "collection " <> label <> " was not found"
+     in CollectionFetchException username label oneLine oneLine
+collectionFetchExceptionHandler
+  username
+  label
+  (CollectionFetchHTTPException cid page e) =
+    let oneLine =
+          "HTTP request to fetch page "
+            <> show page
+            <> " of collection with ID "
+            <> show cid
+            <> " failed"
+     in CollectionFetchException username label oneLine (show e)
+collectionFetchExceptionHandler
+  username
+  label
+  (MetaParseException cid jsonErr) =
+    let oneLine =
+          "failed to parse collection metadata from API response"
+            <> " for collection with ID "
+            <> show cid
+     in CollectionFetchException username label oneLine jsonErr
+collectionFetchExceptionHandler
+  username
+  label
+  (WallpaperURLsParseException jsonErr) =
+    let oneLine = "failed to parse wallpaper URLs from API response"
+     in CollectionFetchException username label oneLine jsonErr
+
+downloadWallpaper ::
+  (MonadUnliftIO m) => FullWallpaperURL -> m ByteString
+downloadWallpaper url =
+  catch
+    (WallhavenAPI.getFullWallpaper url)
+    (throwIO . wallpaperDownloadExceptionHandler url)
+
+wallpaperDownloadExceptionHandler ::
+  FullWallpaperURL -> HTTP.HttpException -> WallhavenSyncException
+wallpaperDownloadExceptionHandler url e =
+  let oneLine = "HTTP request to download wallpaper failed"
+   in WallpaperDownloadException url oneLine (show e)

--- a/src/Wallhaven/Implementation/API.hs
+++ b/src/Wallhaven/Implementation/API.hs
@@ -10,12 +10,13 @@ import Types (FullWallpaperURL, Label, Username)
 import UnliftIO (MonadUnliftIO, catch, throwIO)
 import qualified Wallhaven.API.Action as WallhavenAPI
 import Wallhaven.API.Exception (CollectionURLsFetchException (..))
+import Wallhaven.API.Types (APIKey)
 import Wallhaven.Exception
   ( WallhavenSyncException (CollectionFetchException, WallpaperDownloadException),
   )
 
 getCollectionURLs ::
-  (MonadUnliftIO m) => String -> Username -> Label -> m [FullWallpaperURL]
+  (MonadUnliftIO m) => APIKey -> Username -> Label -> m [FullWallpaperURL]
 getCollectionURLs apiKey username label =
   catch
     (WallhavenAPI.getAllCollectionURLs apiKey username label)

--- a/src/Wallhaven/Implementation/FileSystemDB.hs
+++ b/src/Wallhaven/Implementation/FileSystemDB.hs
@@ -11,14 +11,16 @@ import UnliftIO.IO.File
 import Util.FileSystem (deleteFileIfExists)
 import Wallhaven.Exception
 
-deleteWallpaper :: (MonadUnliftIO m) => FilePath -> WallpaperName -> m ()
+type WallpaperDir = FilePath
+
+deleteWallpaper :: (MonadUnliftIO m) => WallpaperDir -> WallpaperName -> m ()
 deleteWallpaper dir name =
   catch
     (deleteFileIfExists $ dir </> name)
     (throwIO . deleteWallpaperExceptionHandler dir name)
 
 deleteWallpaperExceptionHandler ::
-  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
+  WallpaperDir -> WallpaperName -> IOError -> WallhavenSyncException
 deleteWallpaperExceptionHandler dir name e
   | isPermissionError e =
       let oneLine =
@@ -32,14 +34,14 @@ deleteWallpaperExceptionHandler dir name e
         (show e)
 
 saveWallpaper ::
-  (MonadUnliftIO m) => FilePath -> WallpaperName -> Wallpaper -> m ()
+  (MonadUnliftIO m) => WallpaperDir -> WallpaperName -> Wallpaper -> m ()
 saveWallpaper dir name wallpaper = do
   catch
     (writeBinaryFile (dir </> name) wallpaper)
     (throwIO . saveWallpaperExceptionHandler dir name)
 
 saveWallpaperExceptionHandler ::
-  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
+  WallpaperDir -> WallpaperName -> IOError -> WallhavenSyncException
 saveWallpaperExceptionHandler dir name e
   | isPermissionError e =
       let oneLine =
@@ -52,13 +54,13 @@ saveWallpaperExceptionHandler dir name e
         ("failed to save wallpaper to file " <> (dir </> name))
         (show e)
 
-initDB :: (MonadUnliftIO m) => FilePath -> m ()
+initDB :: (MonadUnliftIO m) => WallpaperDir -> m ()
 initDB dir =
   catch
     (createDirectoryIfMissing True dir)
     (throwIO . initDBExceptionHandler dir)
 
-initDBExceptionHandler :: FilePath -> IOError -> WallhavenSyncException
+initDBExceptionHandler :: WallpaperDir -> IOError -> WallhavenSyncException
 initDBExceptionHandler dir e
   | isPermissionError e =
       let oneLine =
@@ -72,14 +74,14 @@ initDBExceptionHandler dir e
         ("failed to create wallpaper directory '" <> dir <> "'")
         (show e)
 
-getDownloadedWallpapers :: (MonadUnliftIO m) => FilePath -> m [WallpaperName]
+getDownloadedWallpapers :: (MonadUnliftIO m) => WallpaperDir -> m [WallpaperName]
 getDownloadedWallpapers dir =
   catch
     (listDirectory dir)
     (throwIO . getDownloadedWallpapersExceptionHandler dir)
 
 getDownloadedWallpapersExceptionHandler ::
-  FilePath -> IOError -> WallhavenSyncException
+  WallpaperDir -> IOError -> WallhavenSyncException
 getDownloadedWallpapersExceptionHandler dir e
   | isPermissionError e =
       let oneLine =

--- a/src/Wallhaven/Implementation/FileSystemDB.hs
+++ b/src/Wallhaven/Implementation/FileSystemDB.hs
@@ -1,6 +1,12 @@
 -- Provides functions that implement Wallhaven Database interface to be used when
 -- constructing environments.
-module Wallhaven.Implementation.FileSystemDB (deleteWallpaper, saveWallpaper, initDB, getDownloadedWallpapers) where
+module Wallhaven.Implementation.FileSystemDB
+  ( deleteWallpaper,
+    saveWallpaper,
+    initDB,
+    getDownloadedWallpapers,
+  )
+where
 
 import System.FilePath ((</>))
 import System.IO.Error (isPermissionError)

--- a/src/Wallhaven/Implementation/FileSystemDB.hs
+++ b/src/Wallhaven/Implementation/FileSystemDB.hs
@@ -1,0 +1,94 @@
+-- Provides functions that implement Wallhaven Database interface to be used when
+-- constructing environments.
+module Wallhaven.Implementation.FileSystemDB (deleteWallpaper, saveWallpaper, initDB, getDownloadedWallpapers) where
+
+import System.FilePath ((</>))
+import System.IO.Error (isPermissionError)
+import Types (Wallpaper, WallpaperName)
+import UnliftIO
+import UnliftIO.Directory
+import UnliftIO.IO.File
+import Util.FileSystem (deleteFileIfExists)
+import Wallhaven.Exception
+
+deleteWallpaper :: (MonadUnliftIO m) => FilePath -> WallpaperName -> m ()
+deleteWallpaper dir name =
+  catch
+    (deleteFileIfExists $ dir </> name)
+    (throwIO . deleteWallpaperExceptionHandler dir name)
+
+deleteWallpaperExceptionHandler ::
+  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
+deleteWallpaperExceptionHandler dir name e
+  | isPermissionError e =
+      let oneLine =
+            "no permission to delete wallpaper file " <> (dir </> name)
+          verbose = show e
+       in DeleteWallpaperException name oneLine verbose
+  | otherwise =
+      DeleteWallpaperException
+        name
+        ("failed to delete wallpaper file " <> (dir </> name))
+        (show e)
+
+saveWallpaper ::
+  (MonadUnliftIO m) => FilePath -> WallpaperName -> Wallpaper -> m ()
+saveWallpaper dir name wallpaper = do
+  catch
+    (writeBinaryFile (dir </> name) wallpaper)
+    (throwIO . saveWallpaperExceptionHandler dir name)
+
+saveWallpaperExceptionHandler ::
+  FilePath -> WallpaperName -> IOError -> WallhavenSyncException
+saveWallpaperExceptionHandler dir name e
+  | isPermissionError e =
+      let oneLine =
+            "no permission to save wallpaper to file " <> (dir </> name)
+          verbose = show e
+       in SaveWallpaperException name oneLine verbose
+  | otherwise =
+      SaveWallpaperException
+        name
+        ("failed to save wallpaper to file " <> (dir </> name))
+        (show e)
+
+initDB :: (MonadUnliftIO m) => FilePath -> m ()
+initDB dir =
+  catch
+    (createDirectoryIfMissing True dir)
+    (throwIO . initDBExceptionHandler dir)
+
+initDBExceptionHandler :: FilePath -> IOError -> WallhavenSyncException
+initDBExceptionHandler dir e
+  | isPermissionError e =
+      let oneLine =
+            "no permission to create wallpaper directory '"
+              <> dir
+              <> "'"
+          verbose = show e
+       in InitDBException oneLine verbose
+  | otherwise =
+      InitDBException
+        ("failed to create wallpaper directory '" <> dir <> "'")
+        (show e)
+
+getDownloadedWallpapers :: (MonadUnliftIO m) => FilePath -> m [WallpaperName]
+getDownloadedWallpapers dir =
+  catch
+    (listDirectory dir)
+    (throwIO . getDownloadedWallpapersExceptionHandler dir)
+
+getDownloadedWallpapersExceptionHandler ::
+  FilePath -> IOError -> WallhavenSyncException
+getDownloadedWallpapersExceptionHandler dir e
+  | isPermissionError e =
+      let oneLine =
+            "no permission to list contents of wallpaper directory '"
+              <> dir
+              <> "'"
+          verbose = show e
+       in InitDBException oneLine verbose
+  | otherwise =
+      InitDBException
+        ("failed to list contents of wallpaper directory '" <> dir <> "'")
+        (show e)

--- a/test/Util/RetrySpec.hs
+++ b/test/Util/RetrySpec.hs
@@ -1,4 +1,4 @@
-module RetrySpec (spec) where
+module Util.RetrySpec (spec) where
 
 import Control.Monad.State (get, liftIO, modify, runStateT)
 import Retry

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -32,6 +32,8 @@ library wallhaven-sync-internal
         Wallhaven.API.Exception
         Wallhaven.API.Types
         Wallhaven.API.Logic
+        Wallhaven.Implementation.API
+        Wallhaven.Implementation.FileSystemDB
 
     hs-source-dirs:     src
     default-language:   Haskell2010

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -17,9 +17,9 @@ source-repository head
 
 library wallhaven-sync-internal
     exposed-modules:
-        Retry
         Types
         Util.Time
+        Util.Retry
         Util.List
         Util.Batch
         Util.HTTP
@@ -93,7 +93,7 @@ test-suite spec
     other-modules:
         Wallhaven.LogicSpec
         Wallhaven.ActionSpec
-        RetrySpec
+        Util.RetrySpec
         Util.Gen
         Util.BatchSpec
         Wallhaven.API.TypesSpec


### PR DESCRIPTION
Currently all implementation details of `Env` typeclass instances are in `Wallhaven.Env` module. The implementation details should be moved out of `Wallhaven.Env` module for two reasons - 

1. environment modules should be simple,
2. implementation of typeclassses based on low-level libraries should be reusable with multiple environments. 

So, this PR creates two new modules - `Wallhaven.Implementation.API` and `Wallhaven.Implementation.FileSystemDB` and moves all typeclass implementation logic to new functions in these modules. `Wallhaven.Env` now depends on these modules for the implementation of its typeclass instances.