### PR TITLE
Retry to util

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -8,16 +8,9 @@ type WallpaperName = String
 
 type NumParallelDownloads = Int
 
-type Page = Int
-
-type LocalWallpapers = [FilePath]
-
 type Label = String
 
 type CollectionID = Int
-
--- Either local wallpaper path or preview or full wallpaper URL.
-type WallpaperPath = String
 
 type Username = String
 

--- a/src/Util/HTTP.hs
+++ b/src/Util/HTTP.hs
@@ -15,9 +15,9 @@ import Network.HTTP.Simple
     httpBS,
   )
 import Network.HTTP.Types (tooManyRequests429)
-import Retry (MaxAttempts, RetryDelayMicros, retryM)
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (throwIO, try)
+import Util.Retry (MaxAttempts, RetryDelayMicros, retryM)
 
 httpBSWithRetry ::
   (MonadUnliftIO m) =>

--- a/src/Util/Retry.hs
+++ b/src/Util/Retry.hs
@@ -1,4 +1,4 @@
-module Retry (retryM, MaxAttempts, RetryDelayMicros) where
+module Util.Retry (retryM, MaxAttempts, RetryDelayMicros) where
 
 import UnliftIO (MonadIO)
 import UnliftIO.Concurrent (threadDelay)

--- a/src/Wallhaven/API/Action.hs
+++ b/src/Wallhaven/API/Action.hs
@@ -4,8 +4,14 @@ import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Network.HTTP.Simple (Request, parseRequest_)
 import Types
+  ( CollectionID,
+    FullWallpaperURL,
+    Label,
+    NumParallelDownloads,
+    Username,
+  )
 import UnliftIO (MonadUnliftIO)
-import UnliftIO.Exception
+import UnliftIO.Exception (catch, fromEither, throwIO)
 import Util.Batch (batchedM)
 import Util.HTTP (httpBSWithRetry, isTooManyRequestsException)
 import qualified Util.Retry as Retry
@@ -18,7 +24,7 @@ import Wallhaven.API.Logic
     wallhavenCollectionPageRequest,
     wallhavenCollectionsRequest,
   )
-import Wallhaven.API.Types (APIKey)
+import Wallhaven.API.Types (APIKey, Page)
 
 getAllCollectionURLs ::
   (MonadUnliftIO m) => APIKey -> Username -> Label -> m [FullWallpaperURL]

--- a/src/Wallhaven/API/Action.hs
+++ b/src/Wallhaven/API/Action.hs
@@ -3,12 +3,12 @@ module Wallhaven.API.Action (getAllCollectionURLs, getFullWallpaper) where
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Network.HTTP.Simple (Request, parseRequest_)
-import qualified Retry
 import Types
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception
 import Util.Batch (batchedM)
 import Util.HTTP (httpBSWithRetry, isTooManyRequestsException)
+import qualified Util.Retry as Retry
 import Util.Time (seconds)
 import qualified Wallhaven.API.Exception as Exception
 import Wallhaven.API.Logic

--- a/src/Wallhaven/API/Exception.hs
+++ b/src/Wallhaven/API/Exception.hs
@@ -1,8 +1,9 @@
 module Wallhaven.API.Exception where
 
 import qualified Network.HTTP.Simple as HTTP
-import Types
+import Types (CollectionID, Label)
 import UnliftIO.Exception (Exception, Typeable)
+import Wallhaven.API.Types (Page)
 
 type JSONParseError = String
 

--- a/src/Wallhaven/API/Types.hs
+++ b/src/Wallhaven/API/Types.hs
@@ -5,6 +5,8 @@ import Types (CollectionID, FullWallpaperURL, Label)
 
 type APIKey = String
 
+type Page = Int
+
 data WallhavenCollection = WallhavenCollection
   { wallhavenCollectionID :: CollectionID,
     wallhavenCollectionLabel :: Label

--- a/src/Wallhaven/Implementation/FileSystemDB.hs
+++ b/src/Wallhaven/Implementation/FileSystemDB.hs
@@ -1,6 +1,12 @@
 -- Provides functions that implement Wallhaven Database interface to be used when
 -- constructing environments.
-module Wallhaven.Implementation.FileSystemDB (deleteWallpaper, saveWallpaper, initDB, getDownloadedWallpapers) where
+module Wallhaven.Implementation.FileSystemDB
+  ( deleteWallpaper,
+    saveWallpaper,
+    initDB,
+    getDownloadedWallpapers,
+  )
+where
 
 import System.FilePath ((</>))
 import System.IO.Error (isPermissionError)

--- a/src/Wallhaven/Logic.hs
+++ b/src/Wallhaven/Logic.hs
@@ -3,5 +3,5 @@ module Wallhaven.Logic (wallpaperName) where
 import qualified Data.List.Split as List
 import Types
 
-wallpaperName :: WallpaperPath -> WallpaperName
+wallpaperName :: FullWallpaperURL -> WallpaperName
 wallpaperName = last . List.splitOn "/"

--- a/test/Util/RetrySpec.hs
+++ b/test/Util/RetrySpec.hs
@@ -1,4 +1,4 @@
-module RetrySpec (spec) where
+module Util.RetrySpec (spec) where
 
 import Control.Monad.State (get, liftIO, modify, runStateT)
 import Retry

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -17,9 +17,9 @@ source-repository head
 
 library wallhaven-sync-internal
     exposed-modules:
-        Retry
         Types
         Util.Time
+        Util.Retry
         Util.List
         Util.Batch
         Util.HTTP
@@ -93,7 +93,7 @@ test-suite spec
     other-modules:
         Wallhaven.LogicSpec
         Wallhaven.ActionSpec
-        RetrySpec
+        Util.RetrySpec
         Util.Gen
         Util.BatchSpec
         Wallhaven.API.TypesSpec


### PR DESCRIPTION
Move `Retry` module to util directory and rename it to `Util.Retry`. All other util modules are inside the util directory so it makes sense for `Retry` module to be there as well. 