### PR TITLE
Move Types to Wallhaven directory

### DIFF
--- a/app/Wallhaven/CLI.hs
+++ b/app/Wallhaven/CLI.hs
@@ -2,9 +2,9 @@ module Wallhaven.CLI (runCLIApp) where
 
 import Control.Monad.Reader (ReaderT (runReaderT))
 import Options.Applicative
-import Types
 import Wallhaven.Action (syncAllWallpapers)
 import Wallhaven.Env (Config (Config), Env (Env))
+import Wallhaven.Types
 
 defaultWallpaperDir :: FilePath
 defaultWallpaperDir = "/Users/home/wallpapers"

--- a/app/Wallhaven/Env.hs
+++ b/app/Wallhaven/Env.hs
@@ -1,11 +1,22 @@
 module Wallhaven.Env (Env (..), Config (..)) where
 
 import Control.Monad.Reader (ReaderT, asks)
-import qualified Types
 import UnliftIO (MonadUnliftIO)
 import qualified Wallhaven.Implementation.API as API
 import qualified Wallhaven.Implementation.FileSystemDB as FileSystemDB
 import Wallhaven.Monad
+  ( HasDebug (..),
+    HasDeleteUnliked (..),
+    HasLog (..),
+    HasSyncParallelization (..),
+    MonadDeleteWallpaper (..),
+    MonadDownloadWallpaper (..),
+    MonadGetCollectionURLs (..),
+    MonadGetDownloadedWallpapers (..),
+    MonadInitDB (..),
+    MonadSaveWallpaper (..),
+  )
+import qualified Wallhaven.Types as Types
 import Prelude hiding (log)
 
 -- Environment record

--- a/src/Wallhaven/API/Action.hs
+++ b/src/Wallhaven/API/Action.hs
@@ -3,13 +3,6 @@ module Wallhaven.API.Action (getAllCollectionURLs, getFullWallpaper) where
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Network.HTTP.Simple (Request, parseRequest_)
-import Types
-  ( CollectionID,
-    FullWallpaperURL,
-    Label,
-    NumParallelDownloads,
-    Username,
-  )
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (catch, fromEither, throwIO)
 import Util.Batch (batchedM)
@@ -25,6 +18,13 @@ import Wallhaven.API.Logic
     wallhavenCollectionsRequest,
   )
 import Wallhaven.API.Types (APIKey, Page)
+import Wallhaven.Types
+  ( CollectionID,
+    FullWallpaperURL,
+    Label,
+    NumParallelDownloads,
+    Username,
+  )
 
 getAllCollectionURLs ::
   (MonadUnliftIO m) => APIKey -> Username -> Label -> m [FullWallpaperURL]

--- a/src/Wallhaven/API/Exception.hs
+++ b/src/Wallhaven/API/Exception.hs
@@ -1,9 +1,9 @@
 module Wallhaven.API.Exception where
 
 import qualified Network.HTTP.Simple as HTTP
-import Types (CollectionID, Label)
 import UnliftIO.Exception (Exception, Typeable)
 import Wallhaven.API.Types (Page)
+import Wallhaven.Types (CollectionID, Label)
 
 type JSONParseError = String
 

--- a/src/Wallhaven/API/Logic.hs
+++ b/src/Wallhaven/API/Logic.hs
@@ -14,9 +14,14 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BC8
 import qualified Data.List as List
 import qualified Network.HTTP.Simple as HTTP
-import Types
 import qualified Wallhaven.API.Exception as Exception
 import Wallhaven.API.Types
+import Wallhaven.Types
+  ( CollectionID,
+    FullWallpaperURL,
+    Label,
+    Username,
+  )
 
 findCollectionByLabel ::
   String -> WallhavenCollectionsResponse -> Maybe WallhavenCollection

--- a/src/Wallhaven/API/Types.hs
+++ b/src/Wallhaven/API/Types.hs
@@ -1,7 +1,7 @@
 module Wallhaven.API.Types where
 
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
-import Types (CollectionID, FullWallpaperURL, Label)
+import Wallhaven.Types (CollectionID, FullWallpaperURL, Label)
 
 type APIKey = String
 

--- a/src/Wallhaven/Action.hs
+++ b/src/Wallhaven/Action.hs
@@ -5,7 +5,6 @@ import Control.Monad.Reader (MonadReader, asks)
 import qualified Data.List as List
 import Data.Time (nominalDiffTimeToSeconds)
 import Text.Printf (printf)
-import Types (FullWallpaperURL, Label, Username, WallpaperName)
 import UnliftIO
 import UnliftIO.Concurrent (threadDelay)
 import Util.Batch (batchedM_)
@@ -30,6 +29,7 @@ import Wallhaven.Monad
     getSyncParallelization,
     saveWallpaper,
   )
+import Wallhaven.Types (FullWallpaperURL, Label, Username, WallpaperName)
 import Prelude hiding (log, writeFile)
 
 type AppM env m =

--- a/src/Wallhaven/Exception.hs
+++ b/src/Wallhaven/Exception.hs
@@ -3,8 +3,13 @@ module Wallhaven.Exception
   )
 where
 
-import Types
 import UnliftIO (Exception, Typeable)
+import Wallhaven.Types
+  ( FullWallpaperURL,
+    Label,
+    Username,
+    WallpaperName,
+  )
 
 type OneLineError = String
 

--- a/src/Wallhaven/Implementation/API.hs
+++ b/src/Wallhaven/Implementation/API.hs
@@ -6,7 +6,6 @@ import Data.ByteString (ByteString)
 import qualified Network.HTTP.Client.Conduit as HTTP
 import qualified Network.HTTP.Simple as HTTP
 import Network.HTTP.Types.Status (notFound404, unauthorized401)
-import Types (FullWallpaperURL, Label, Username)
 import UnliftIO (MonadUnliftIO, catch, throwIO)
 import qualified Wallhaven.API.Action as WallhavenAPI
 import Wallhaven.API.Exception (CollectionURLsFetchException (..))
@@ -14,6 +13,7 @@ import Wallhaven.API.Types (APIKey)
 import Wallhaven.Exception
   ( WallhavenSyncException (CollectionFetchException, WallpaperDownloadException),
   )
+import Wallhaven.Types (FullWallpaperURL, Label, Username)
 
 getCollectionURLs ::
   (MonadUnliftIO m) => APIKey -> Username -> Label -> m [FullWallpaperURL]

--- a/src/Wallhaven/Implementation/FileSystemDB.hs
+++ b/src/Wallhaven/Implementation/FileSystemDB.hs
@@ -10,12 +10,12 @@ where
 
 import System.FilePath ((</>))
 import System.IO.Error (isPermissionError)
-import Types (Wallpaper, WallpaperName)
 import UnliftIO
 import UnliftIO.Directory
 import UnliftIO.IO.File
 import Util.FileSystem (deleteFileIfExists)
 import Wallhaven.Exception
+import Wallhaven.Types (Wallpaper, WallpaperName)
 
 type WallpaperDir = FilePath
 

--- a/src/Wallhaven/Logic.hs
+++ b/src/Wallhaven/Logic.hs
@@ -1,7 +1,7 @@
 module Wallhaven.Logic (wallpaperName) where
 
 import qualified Data.List.Split as List
-import Types
+import Wallhaven.Types (FullWallpaperURL, WallpaperName)
 
 wallpaperName :: FullWallpaperURL -> WallpaperName
 wallpaperName = last . List.splitOn "/"

--- a/src/Wallhaven/Monad.hs
+++ b/src/Wallhaven/Monad.hs
@@ -15,7 +15,13 @@ module Wallhaven.Monad
 where
 
 import Data.ByteString (ByteString)
-import Types
+import Wallhaven.Types
+  ( FullWallpaperURL,
+    Label,
+    Username,
+    Wallpaper,
+    WallpaperName,
+  )
 
 class HasDebug a where
   getDebug :: a -> Bool

--- a/src/Wallhaven/Types.hs
+++ b/src/Wallhaven/Types.hs
@@ -1,4 +1,4 @@
-module Types where
+module Wallhaven.Types where
 
 import Data.ByteString (ByteString)
 

--- a/wallhaven-sync.cabal
+++ b/wallhaven-sync.cabal
@@ -17,13 +17,13 @@ source-repository head
 
 library wallhaven-sync-internal
     exposed-modules:
-        Types
         Util.Time
         Util.Retry
         Util.List
         Util.Batch
         Util.HTTP
         Util.FileSystem
+        Wallhaven.Types
         Wallhaven.Logic
         Wallhaven.Exception
         Wallhaven.Monad


### PR DESCRIPTION
The top-level `Types` modules only has types for the top-level Wallhaven modules which are in the `src/Wallhaven` directory. It makes sense for `Types` module to live there as well for consistency.